### PR TITLE
Standard approach

### DIFF
--- a/todo
+++ b/todo
@@ -16,5 +16,6 @@ VALUE_SPAN="<span font_desc=\"${VALUE_FONT}\" color=\"${VALUE_COLOR}\"> $COUNT</
 echo "${ICON_SPAN}${VALUE_SPAN}"
 
 if [ -n "$button" ]; then
-    /usr/bin/i3-msg -q exec "/usr/bin/gnome-terminal --class=floating_window -e 'td --interactive'"
+    /usr/bin/i3-msg -q exec "x-terminal-emulator -c floating_window td --interactive"
+    
 fi

--- a/todo
+++ b/todo
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # get font and icon specifics from xresource file
-VALUE_FONT=${font:-$(xrescat i3xrocks.value.font "Source Code Pro 12")}
+VALUE_FONT=${font:-$(xrescat i3xrocks.value.font "JetBrains Mono Medium 13")}
 VALUE_COLOR=${color:-$(xrescat i3xrocks.value.color "#D8DEE9")}
 LABEL_COLOR=${label_color:-$(xrescat i3xrocks.label.color "#7B8394")}
 LABEL_ICON=${label_icon:-$(xrescat i3xrocks.label.todo " ")}

--- a/todo
+++ b/todo
@@ -1,15 +1,15 @@
 #!/bin/sh
 
 # get font and icon specifics from xresource file
-VALUE_FONT=${font:-$(xrescat i3xrocks.value.font "JetBrains Mono Medium 13")}
+VALUE_FONT=${font:-$(xrescat i3xrocks.value.font "Source Code Pro 12")}
 VALUE_COLOR=${color:-$(xrescat i3xrocks.value.color "#D8DEE9")}
 LABEL_COLOR=${label_color:-$(xrescat i3xrocks.label.color "#7B8394")}
 LABEL_ICON=${label_icon:-$(xrescat i3xrocks.label.todo " ")}
 
-# format net usage output with fixed width
+# format todos' count output with fixed width
 COUNT="$(printf "%2d" "$(td count)")"
 
-# output net usage using pango markup
+# output todos' count using pango markup
 ICON_SPAN="<span color=\"${LABEL_COLOR}\">$LABEL_ICON</span>"
 VALUE_SPAN="<span font_desc=\"${VALUE_FONT}\" color=\"${VALUE_COLOR}\"> $COUNT</span>"
 


### PR DESCRIPTION
1. There were some comments left on line 9, 12 from the net-traffic which apparently has been used as template. fixed
2. Font 'JetBrains Mono' is my personal favourite, but it's quite new and not normally installed on all systems yet. Using it as fallback doesn't seem to be a good idea
3. let the user's terminal of choice which is configured via `x-terminal-emulator` be used. (if not customized then it's `gnome-terminal` though)