### PR TITLE
Add flag to see uncompleted tasks

### DIFF
--- a/todo
+++ b/todo
@@ -7,7 +7,7 @@ LABEL_COLOR=${label_color:-$(xrescat i3xrocks.label.color "#7B8394")}
 LABEL_ICON=${label_icon:-$(xrescat i3xrocks.label.todo " ")}
 
 # format net usage output with fixed width
-COUNT="$(printf "%2d" "$(td count)")"
+COUNT="$(printf "%2d" "$(td count --uncompleted)")"
 
 # output net usage using pango markup
 ICON_SPAN="<span color=\"${LABEL_COLOR}\">$LABEL_ICON</span>"

--- a/todo
+++ b/todo
@@ -1,4 +1,6 @@
-#!/bin/sh
+#!/bin/bash
+
+set -Eeu -o pipefail
 
 # get font and icon specifics from xresource file
 VALUE_FONT=${font:-$(xrescat i3xrocks.value.font "JetBrains Mono Medium 13")}
@@ -6,15 +8,17 @@ VALUE_COLOR=${color:-$(xrescat i3xrocks.value.color "#D8DEE9")}
 LABEL_COLOR=${label_color:-$(xrescat i3xrocks.label.color "#7B8394")}
 LABEL_ICON=${label_icon:-$(xrescat i3xrocks.label.todo " ")}
 
-# format net usage output with fixed width
-COUNT="$(printf "%2d" "$(td count --uncompleted)")"
+# get number of uncompleted tasks from td-cli
+ntask=$(td count --uncompleted | sed 's/[^0-9]*//g')
+COUNT="$(printf ' %-2s' ${ntask: :-1})"
 
-# output net usage using pango markup
+# output number of uncompleted tasks using pango markup
 ICON_SPAN="<span color=\"${LABEL_COLOR}\">$LABEL_ICON</span>"
-VALUE_SPAN="<span font_desc=\"${VALUE_FONT}\" color=\"${VALUE_COLOR}\"> $COUNT</span>"
+VALUE_SPAN="<span font_desc=\"${VALUE_FONT}\" color=\"${VALUE_COLOR}\">$COUNT</span>"
 
 echo "${ICON_SPAN}${VALUE_SPAN}"
 
-if [ -n "$button" ]; then
-    /usr/bin/i3-msg -q exec "/usr/bin/gnome-terminal --class=floating_window -e 'td --interactive --uncompleted'"
+# make the blocklet clickable
+if [ -n "${button-}" ]; then
+    /usr/bin/i3-msg -q exec "/usr/bin/gnome-terminal --class=floating_window -e 'td --interactive  --uncompleted'"
 fi

--- a/todo
+++ b/todo
@@ -11,7 +11,7 @@ UNCOMPLETED=${filter:-$(xrescat i3xrocks.todo.uncompleted "false")}
 
 # get number of uncompleted tasks from td-cli
 FILTER=""
-[[ $UNCOMPLETED == "true" ]] && FILTER="--uncompleted"
+[[ $UNCOMPLETED = "true" ]] && FILTER="--uncompleted"
 ntask=$(td count $FILTER | sed 's/[^0-9]*//g')
 COUNT="$(printf ' %-2s' "${ntask: :-1}")"
 
@@ -23,5 +23,6 @@ echo "${ICON_SPAN}${VALUE_SPAN}"
 
 # make the blocklet clickable
 if [ -n "${button-}" ]; then
-    /usr/bin/i3-msg -q exec "/usr/bin/gnome-terminal --class=floating_window -e 'td --interactive  --uncompleted'"
+    CMD="'td --interactive $FILTER'"
+    /usr/bin/i3-msg -q exec "/usr/bin/gnome-terminal --class=floating_window -e $CMD"
 fi

--- a/todo
+++ b/todo
@@ -6,11 +6,14 @@ set -Eeu -o pipefail
 VALUE_FONT=${font:-$(xrescat i3xrocks.value.font "JetBrains Mono Medium 13")}
 VALUE_COLOR=${color:-$(xrescat i3xrocks.value.color "#D8DEE9")}
 LABEL_COLOR=${label_color:-$(xrescat i3xrocks.label.color "#7B8394")}
-LABEL_ICON=${label_icon:-$(xrescat i3xrocks.label.todo " ")}
+LABEL_ICON=${label_icon:-$(xrescat i3xrocks.label.todo " ")}
+UNCOMPLETED=${filter:-$(xrescat i3xrocks.todo.uncompleted "false")}
 
 # get number of uncompleted tasks from td-cli
-ntask=$(td count --uncompleted | sed 's/[^0-9]*//g')
-COUNT="$(printf ' %-2s' ${ntask: :-1})"
+FILTER=""
+[[ $UNCOMPLETED == "true" ]] && FILTER="--uncompleted"
+ntask=$(td count $FILTER | sed 's/[^0-9]*//g')
+COUNT="$(printf ' %-2s' "${ntask: :-1}")"
 
 # output number of uncompleted tasks using pango markup
 ICON_SPAN="<span color=\"${LABEL_COLOR}\">$LABEL_ICON</span>"

--- a/todo
+++ b/todo
@@ -16,5 +16,5 @@ VALUE_SPAN="<span font_desc=\"${VALUE_FONT}\" color=\"${VALUE_COLOR}\"> $COUNT</
 echo "${ICON_SPAN}${VALUE_SPAN}"
 
 if [ -n "$button" ]; then
-    /usr/bin/i3-msg -q exec "/usr/bin/gnome-terminal --class=floating_window -e 'td --interactive'"
+    /usr/bin/i3-msg -q exec "/usr/bin/gnome-terminal --class=floating_window -e 'td --interactive --uncompleted'"
 fi


### PR DESCRIPTION
The current version shows all completed and uncompleted tasks.  To remove one from the view you need to delete it; however, that means losing history.

I think it would be better to just show `--uncompleted` tasks, so it would hide completed tasks from the view, but allow you to maintain your history if you wanted to review them.

*Note, the completed task only disappears on after you quit and relaunch.*