### PR TITLE
Rewrote syntax of todo script, added tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,29 @@
+name: test
+on:
+  push:
+    branches:
+      - master
+    tags-ignore:
+      - "*"
+  pull_request:
+    branches:
+      - "master"
+
+jobs:
+  test:
+    container: ubuntu:focal
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Prepare test environment
+        shell: bash
+        env:
+          DEBIAN_FRONTEND: noninteractive
+        run: |
+          apt update -qq
+          cp tests/xrescat_mock /usr/bin/xrescat
+          cp tests/i3-msg_mock /usr/bin/i3-msg
+      - name: Run todo test
+        shell: bash
+        run: |
+          tests/todo_test.sh

--- a/scripts/todo
+++ b/scripts/todo
@@ -2,6 +2,8 @@
 
 set -Eeu -o pipefail
 
+BUTTON="${button:-}"
+
 # get font and icon specifics from xresource file
 VALUE_FONT=${font:-$(xrescat i3xrocks.value.font "JetBrains Mono Medium 13")}
 VALUE_COLOR=${color:-$(xrescat i3xrocks.value.color "#D8DEE9")}
@@ -9,20 +11,24 @@ LABEL_COLOR=${label_color:-$(xrescat i3xrocks.label.color "#7B8394")}
 LABEL_ICON=${label_icon:-$(xrescat i3xrocks.label.todo " ")}
 UNCOMPLETED=${filter:-$(xrescat i3xrocks.todo.uncompleted "false")}
 
+BAR_COMMAND="td count"
+CLICK_COMMAND="td --interactive"
+
+if [ "${UNCOMPLETED}" == "true" ]; then
+    BAR_COMMAND="${BAR_COMMAND} --uncompleted"
+    CLICK_COMMAND="${CLICK_COMMAND} --uncompleted"
+fi
+
 # get number of uncompleted tasks from td-cli
-FILTER=""
-[[ $UNCOMPLETED = "true" ]] && FILTER="--uncompleted"
-ntask=$(td count $FILTER | sed 's/[^0-9]*//g')
-COUNT="$(printf ' %-2s' "${ntask: :-1}")"
+COUNT="$(${BAR_COMMAND} | awk '{printf "%2d", $1}')"
 
 # output number of uncompleted tasks using pango markup
 ICON_SPAN="<span color=\"${LABEL_COLOR}\">$LABEL_ICON</span>"
-VALUE_SPAN="<span font_desc=\"${VALUE_FONT}\" color=\"${VALUE_COLOR}\">$COUNT</span>"
+VALUE_SPAN="<span font_desc=\"${VALUE_FONT}\" color=\"${VALUE_COLOR}\"> ${COUNT}</span>"
 
 echo "${ICON_SPAN}${VALUE_SPAN}"
 
 # make the blocklet clickable
-if [ -n "${button-}" ]; then
-    CMD="'td --interactive $FILTER'"
-    /usr/bin/i3-msg -q exec "/usr/bin/gnome-terminal --class=floating_window -e $CMD"
+if [ "x${BUTTON}" == "x1" ]; then
+    /usr/bin/i3-msg -q exec "/usr/bin/gnome-terminal --class=floating_window -e ${CLICK_COMMAND}"
 fi

--- a/tests/fixtures/todo/fifth/td
+++ b/tests/fixtures/todo/fifth/td
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+if [ "${2}" == "--uncompleted" ]; then
+    echo -ne "12\n"
+fi

--- a/tests/fixtures/todo/first/td
+++ b/tests/fixtures/todo/first/td
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo -ne "0\n"

--- a/tests/fixtures/todo/fourth/td
+++ b/tests/fixtures/todo/fourth/td
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo -ne "122\n"

--- a/tests/fixtures/todo/second/td
+++ b/tests/fixtures/todo/second/td
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo -ne "1\n"

--- a/tests/fixtures/todo/third/td
+++ b/tests/fixtures/todo/third/td
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo -ne "22\n"

--- a/tests/i3-msg_mock
+++ b/tests/i3-msg_mock
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -Eeux -o pipefail
+
+echo "i3-msg called with ${@}"
+
+exit 0

--- a/tests/todo_test.sh
+++ b/tests/todo_test.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+set -Eeux -o pipefail
+
+echo ${BASH_SOURCE[0]}
+
+SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")
+cd "${SCRIPT_DIR}"
+
+# Make sure we can handle 0 with leading space
+PATH="$(pwd)/fixtures/todo/first:${PATH}"
+OUTPUT=$(../scripts/todo)
+echo "${OUTPUT}" | grep -q -P '\>\s{2}0\<'
+
+# Make sure we can handle 1 with leading space
+PATH="$(pwd)/fixtures/todo/second:${PATH}"
+OUTPUT=$(../scripts/todo)
+echo "${OUTPUT}" | grep -q -P '\>\s{2}1\<'
+
+# Make sure we can handle 22 without leading space
+PATH="$(pwd)/fixtures/todo/third:${PATH}"
+OUTPUT=$(../scripts/todo)
+echo "${OUTPUT}" | grep -q -P '\>\s22\<'
+
+# Make sure we can handle 122 without leading space
+PATH="$(pwd)/fixtures/todo/fourth:${PATH}"
+OUTPUT=$(../scripts/todo)
+echo "${OUTPUT}" | grep -q -P '\>\s122\<'
+
+# Make sure we can handle 12 with --uncomplete
+PATH="$(pwd)/fixtures/todo/fifth:${PATH}"
+OUTPUT=$(filter=true ../scripts/todo)
+echo "${OUTPUT}" | grep -q -P '\>\s12\<'

--- a/tests/xrescat_mock
+++ b/tests/xrescat_mock
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -Eeux -o pipefail
+
+XRESOURCE="${1}"
+DEFAULT_VALUE="${2}"
+
+echo "${DEFAULT_VALUE}"
+
+exit 0


### PR DESCRIPTION
Following up on regolith-linux/regolith-i3xrocks-config#99, I took the liberty of rewriting its syntax a little to be easier testable/maintainable (IMHO) and added the same tests (plus one additional one covering the `--uncompleted` flag).