### PR TITLE
Added quotes around ${CLICK_COMMAND}

### DIFF
--- a/scripts/todo
+++ b/scripts/todo
@@ -30,5 +30,5 @@ echo "${ICON_SPAN}${VALUE_SPAN}"
 
 # make the blocklet clickable
 if [ "x${BUTTON}" == "x1" ]; then
-    /usr/bin/i3-msg -q exec "/usr/bin/gnome-terminal --class=floating_window -e ${CLICK_COMMAND}"
+    /usr/bin/i3-msg -q exec "/usr/bin/gnome-terminal --class=floating_window -e '${CLICK_COMMAND}'"
 fi

--- a/tests/todo_test.sh
+++ b/tests/todo_test.sh
@@ -31,3 +31,13 @@ echo "${OUTPUT}" | grep -q -P '\>\s122\<'
 PATH="$(pwd)/fixtures/todo/fifth:${PATH}"
 OUTPUT=$(filter=true ../scripts/todo)
 echo "${OUTPUT}" | grep -q -P '\>\s12\<'
+
+# Make sure button command is right
+PATH="$(pwd)/fixtures/todo/fifth:${PATH}"
+OUTPUT=$(filter=false button=1 ../scripts/todo)
+echo "${OUTPUT}" | grep -q -P "i3-msg called with -q exec /usr/bin/gnome-terminal --class=floating_window -e \'td --interactive\'"
+
+# Make sure button command is right with --uncomplete
+PATH="$(pwd)/fixtures/todo/fifth:${PATH}"
+OUTPUT=$(filter=true button=1 ../scripts/todo)
+echo "${OUTPUT}" | grep -q -P "i3-msg called with -q exec /usr/bin/gnome-terminal --class=floating_window -e \'td --interactive --uncompleted\'"


### PR DESCRIPTION
It these quotes are missing, we run into an expansion issue and the
option --interactive is interpreted as an unknown gnome-terminal option.
With the quotes the whole command 'td --interactive' is appended to the
-e gnome-terminal option.

Result of this issue is that mouse clicks on the applet seem to have not
effect. -> This might have been introduced with the pull request #5 

I would be more than happy to write a test (as in #5 ) for this fix to avoid a similar issue. Any help or pointer how to do this with the current test environment are well appreciated.