### PR TITLE
Replaced option -e with --

### DIFF
--- a/scripts/todo
+++ b/scripts/todo
@@ -30,5 +30,5 @@ echo "${ICON_SPAN}${VALUE_SPAN}"
 
 # make the blocklet clickable
 if [ "x${BUTTON}" == "x1" ]; then
-    /usr/bin/i3-msg -q exec "/usr/bin/gnome-terminal --class=floating_window -e '${CLICK_COMMAND}'"
+    /usr/bin/i3-msg -q exec "/usr/bin/gnome-terminal --class=floating_window -- ${CLICK_COMMAND}"
 fi

--- a/tests/todo_test.sh
+++ b/tests/todo_test.sh
@@ -35,9 +35,9 @@ echo "${OUTPUT}" | grep -q -P '\>\s12\<'
 # Make sure button command is right
 PATH="$(pwd)/fixtures/todo/fifth:${PATH}"
 OUTPUT=$(filter=false button=1 ../scripts/todo)
-echo "${OUTPUT}" | grep -q -P "i3-msg called with -q exec /usr/bin/gnome-terminal --class=floating_window -e \'td --interactive\'"
+echo "${OUTPUT}" | grep -q -P "i3-msg called with -q exec /usr/bin/gnome-terminal --class=floating_window -- td --interactive"
 
 # Make sure button command is right with --uncomplete
 PATH="$(pwd)/fixtures/todo/fifth:${PATH}"
 OUTPUT=$(filter=true button=1 ../scripts/todo)
-echo "${OUTPUT}" | grep -q -P "i3-msg called with -q exec /usr/bin/gnome-terminal --class=floating_window -e \'td --interactive --uncompleted\'"
+echo "${OUTPUT}" | grep -q -P "i3-msg called with -q exec /usr/bin/gnome-terminal --class=floating_window -- td --interactive --uncompleted"


### PR DESCRIPTION
This commit replaces the -e option with -- to get rid of the following
warning and to be prepared for future updates of gnome-terminal.

```
# Option “-e” is deprecated and might be removed in a later version of gnome-terminal.
# Use “-- ” to terminate the options and put the command line to execute after it.
```

-> Sorry for the additional pull request, but I thought this might be useful.